### PR TITLE
Fix UTC timezone leak in event time displays (#39)

### DIFF
--- a/app/e/[slug]/manage/CampaignFinalizeModal.tsx
+++ b/app/e/[slug]/manage/CampaignFinalizeModal.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import { X, MapPin, User, Check, Loader2, Calendar, ChevronDown, ChevronRight, Info, AlertTriangle } from 'lucide-react';
-import { format } from 'date-fns';
+import { ClientDate, ClientTimezone } from '@/components/ClientDate';
 
 interface SlotVote {
     participantId: number;
@@ -200,7 +200,6 @@ export function CampaignFinalizeModal({ slug, minSessions, slots }: CampaignFina
                         <div className="space-y-1.5 max-h-56 overflow-y-auto pr-1">
                             {slots.map(slot => {
                                 const isSelected = selectedSlotIds.has(slot.id);
-                                const d = new Date(slot.startTime);
                                 return (
                                     <label
                                         key={slot.id}
@@ -216,8 +215,9 @@ export function CampaignFinalizeModal({ slug, minSessions, slots }: CampaignFina
                                         </div>
                                         <div className="flex-1 min-w-0">
                                             <div className="font-medium text-sm text-slate-200">
-                                                {format(d, 'EEE, MMM d')}
-                                                <span className="text-slate-400 font-normal ml-2">{format(d, 'h:mm a')}</span>
+                                                <ClientDate date={slot.startTime} formatStr="EEE, MMM d" />
+                                                <ClientDate date={slot.startTime} formatStr="h:mm a" className="text-slate-400 font-normal ml-2" />
+                                                <ClientTimezone className="ml-1 text-slate-500 font-normal" />
                                             </div>
                                             <div className="flex gap-3 mt-0.5 text-xs">
                                                 <span

--- a/app/e/[slug]/manage/CampaignSessionsView.tsx
+++ b/app/e/[slug]/manage/CampaignSessionsView.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { format } from 'date-fns';
+import { ClientDate, ClientTimezone } from '@/components/ClientDate';
 import { Check, MapPin, User, Loader2, X } from 'lucide-react';
 
 type Voter = {
@@ -282,13 +282,10 @@ export function CampaignSessionsView({ slug, groups, minPlayers }: Props) {
                                                 </button>
                                             )}
                                             <div className="text-sm shrink-0 mr-1">
-                                                <span className="font-medium text-slate-200" suppressHydrationWarning>
-                                                    {format(new Date(slot.startTime), 'EEE, MMM d')}
-                                                </span>
+                                                <ClientDate date={slot.startTime} formatStr="EEE, MMM d" className="font-medium text-slate-200" />
                                                 <span className="text-slate-500 mx-1.5">@</span>
-                                                <span className="text-slate-300" suppressHydrationWarning>
-                                                    {format(new Date(slot.startTime), 'h:mm a')}
-                                                </span>
+                                                <ClientDate date={slot.startTime} formatStr="h:mm a" className="text-slate-300" />
+                                                <ClientTimezone className="ml-1 text-slate-500" />
                                             </div>
                                             <div className="flex flex-wrap gap-1 flex-1">
                                                 {coreVoters.map(v => (

--- a/app/e/[slug]/page.tsx
+++ b/app/e/[slug]/page.tsx
@@ -9,7 +9,7 @@ import { VotingInterface } from "@/components/VotingInterface";
 import { FinalizedEventView } from "@/components/FinalizedEventView";
 import { CampaignStatusBanner } from "@/components/CampaignStatusBanner";
 import Link from "next/link";
-import { format } from "date-fns";
+import { ClientDate, ClientTimezone } from "@/components/ClientDate";
 
 interface PageProps {
     params: { slug: string };
@@ -234,8 +234,6 @@ export default async function EventPage({ params, searchParams }: PageProps) {
                                     </div>
                                     <div className="space-y-2">
                                         {event.finalizedSessions.map((session: any, index: number) => {
-                                            const start = new Date(session.timeSlot.startTime);
-                                            const end = new Date(session.timeSlot.endTime);
                                             return (
                                                 <div key={session.id} className="bg-slate-950/50 rounded-xl p-3 flex items-center gap-3 border border-slate-800">
                                                     <div className="w-7 h-7 rounded-full bg-indigo-900/50 flex items-center justify-center text-indigo-300 font-bold text-xs shrink-0">
@@ -243,10 +241,11 @@ export default async function EventPage({ params, searchParams }: PageProps) {
                                                     </div>
                                                     <div className="flex-1 min-w-0">
                                                         <div className="font-semibold text-slate-200 text-sm">
-                                                            {format(start, "EEEE, MMMM do, yyyy")}
+                                                            <ClientDate date={session.timeSlot.startTime} formatStr="EEEE, MMMM do, yyyy" />
                                                         </div>
                                                         <div className="text-xs text-indigo-300">
-                                                            {format(start, "h:mm a")} – {format(end, "h:mm a")}
+                                                            <ClientDate date={session.timeSlot.startTime} formatStr="h:mm a" /> – <ClientDate date={session.timeSlot.endTime} formatStr="h:mm a" />
+                                                            <ClientTimezone className="ml-1 text-indigo-300/70" />
                                                         </div>
                                                     </div>
                                                     <a

--- a/app/profile/ProfileDashboard.tsx
+++ b/app/profile/ProfileDashboard.tsx
@@ -4,7 +4,7 @@ import { useEventHistory } from "@/hooks/useEventHistory";
 import Link from "next/link";
 import { ArrowLeft, User as UserIcon, Calendar, Clock, RefreshCw, Send, Lock } from "lucide-react";
 import { useEffect, useState } from "react";
-import { format } from "date-fns";
+import { ClientDate } from "@/components/ClientDate";
 import { sendGlobalMagicLink } from "@/features/auth/server/magic-link";
 
 
@@ -170,8 +170,10 @@ export function ProfileDashboard({ serverEvents = [], isTelegramSynced, isDiscor
                                             </h3>
                                             <p className="text-xs text-slate-500 font-mono mt-1">
                                                 {event.scheduledDate
-                                                    ? format(new Date(event.scheduledDate), "MMM d, yyyy")
-                                                    : (event.status === 'CANCELLED' ? "Original Date: " + format(new Date(event.lastVisited), "MMM d") : "Draft / Scheduling...")
+                                                    ? <ClientDate date={event.scheduledDate} formatStr="MMM d, yyyy" />
+                                                    : (event.status === 'CANCELLED'
+                                                        ? <>Original Date: <ClientDate date={event.lastVisited} formatStr="MMM d" /></>
+                                                        : "Draft / Scheduling...")
                                                 }
                                             </p>
                                         </div>

--- a/components/ManageSlots.tsx
+++ b/components/ManageSlots.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Loader2, Trash2, Edit2, Plus, X } from "lucide-react";
 import { DateTimeRangeInputs } from "./DateTimeRangeInputs";
+import { ClientDate, ClientTimezone } from "./ClientDate";
 
 interface Slot {
     id: number;
@@ -234,9 +235,10 @@ export function ManageSlots({ slug, slots }: ManageSlotsProps) {
                         ) : (
                             <div className="flex items-center justify-between">
                                 <div className="text-sm text-slate-300">
-                                    <span suppressHydrationWarning>{new Date(slot.startTime).toLocaleString([], { dateStyle: 'short', timeStyle: 'short' })}</span>
+                                    <ClientDate date={slot.startTime} formatStr="P, p" />
                                     <span className="text-slate-500 mx-2">to</span>
-                                    <span suppressHydrationWarning>{new Date(slot.endTime).toLocaleString([], { timeStyle: 'short' })}</span>
+                                    <ClientDate date={slot.endTime} formatStr="p" />
+                                    <ClientTimezone className="ml-1 text-slate-500" />
                                 </div>
                                 <div className="flex items-center gap-1">
                                     <button

--- a/components/QuickSelectionCalendar.tsx
+++ b/components/QuickSelectionCalendar.tsx
@@ -7,6 +7,7 @@ import {
 } from "date-fns";
 import { ChevronLeft, ChevronRight, Check, HelpCircle, X, Info, Loader2, Home } from "lucide-react";
 import { clsx } from "clsx";
+import { ClientDate, ClientTimezone } from "./ClientDate";
 
 interface Slot {
     id: number;
@@ -284,6 +285,7 @@ export function QuickSelectionCalendar({
 
                     <span className="text-sm font-semibold text-slate-200 shrink-0">
                         {format(viewDate, "MMMM yyyy")}
+                        <ClientTimezone className="ml-1.5 text-[10px] font-normal text-slate-500" />
                     </span>
 
                     {/* Next month button */}
@@ -358,7 +360,6 @@ export function QuickSelectionCalendar({
                                                 key={slot.id}
                                                 data-slot-id={slot.id}
                                                 onPointerDown={(e) => handleSlotPointerDown(e, slot.id)}
-                                                suppressHydrationWarning
                                                 className={clsx(
                                                     "flex-1 flex items-center justify-center",
                                                     "rounded text-[9px] sm:text-[10px] font-medium cursor-pointer transition-colors",
@@ -366,7 +367,7 @@ export function QuickSelectionCalendar({
                                                     slotColor(votes[slot.id])
                                                 )}
                                             >
-                                                {format(new Date(slot.startTime), "ha").toLowerCase()}
+                                                <ClientDate date={slot.startTime} formatStr="ha" className="lowercase" />
                                             </div>
                                         ))}
                                     </div>

--- a/components/VotingInterface.tsx
+++ b/components/VotingInterface.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { format, parseISO } from "date-fns";
-import { ClientTimezone } from "./ClientDate";
+import { ClientDate, ClientTimezone } from "./ClientDate";
 import { Check, HelpCircle, X, User as UserIcon, Loader2, LayoutList, CalendarDays, CalendarRange, Info } from "lucide-react";
 import { clsx } from "clsx";
 import { usePathname, useSearchParams } from "next/navigation";
@@ -289,8 +288,6 @@ export function VotingInterface({ eventId, initialSlots, participants, minPlayer
                         </div>
 
                         {slots.map(slot => {
-                            const start = new Date(slot.startTime);
-                            const end = new Date(slot.endTime);
                             const myVote = votes[slot.id];
                             const totalYes = slot.counts.yes;
                             const isViable = totalYes >= minPlayers;
@@ -306,10 +303,10 @@ export function VotingInterface({ eventId, initialSlots, participants, minPlayer
                                     <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
                                         <div className="text-center sm:text-left">
                                             <div className="font-semibold text-lg text-slate-200">
-                                                {format(start, "EEEE, MMMM do")}
+                                                <ClientDate date={slot.startTime} formatStr="EEEE, MMMM do" />
                                             </div>
                                             <p className="text-sm text-indigo-200">
-                                                {format(start, "h:mm a")} - {format(end, "h:mm a")} <ClientTimezone className="text-indigo-300/70 ml-1" />
+                                                <ClientDate date={slot.startTime} formatStr="h:mm a" /> - <ClientDate date={slot.endTime} formatStr="h:mm a" /> <ClientTimezone className="text-indigo-300/70 ml-1" />
                                             </p>
                                             <div className="mt-2 flex gap-2 text-xs">
                                                 <span className="text-green-400">{slot.counts.yes} Yes</span>


### PR DESCRIPTION
## Summary

Fixes the timezone discrepancy reported in #39, where the event management page showed UTC times (e.g. "Friday 12AM") instead of the viewer's local time ("Thursday 7PM CST"), causing scheduling miscommunication.

The app already has a purpose-built `ClientDate`/`ClientTimezone` module (`components/ClientDate.tsx`) that renders dates client-side only to avoid SSR/local hydration mismatches. It was used in some places but bypassed in others, which rendered DB-stored UTC times directly.

### Root cause
Components rendered UTC `Date`s with `date-fns format()` / `toLocaleString` either:
- in a **server component** (permanent UTC, never corrected) — public event page finalized sessions, or
- in a **client component with `suppressHydrationWarning`** (pins the server's UTC value on screen) — `ManageSlots`, `CampaignSessionsView`, `QuickSelectionCalendar` slot strips, or
- in a **client component without suppression** (UTC flash + hydration error, then corrects to local) — `VotingInterface`, `ProfileDashboard`.

### Changes
Routed every event-time display through `ClientDate`, and added a `ClientTimezone` label wherever a time is shown so viewers always know which zone they're seeing:

- `components/ManageSlots.tsx` — the component from the issue report
- `app/e/[slug]/page.tsx` — finalized campaign sessions (was permanent UTC)
- `app/e/[slug]/manage/CampaignSessionsView.tsx`
- `app/e/[slug]/manage/CampaignFinalizeModal.tsx`
- `components/VotingInterface.tsx`
- `components/QuickSelectionCalendar.tsx` (slot strips + a header tz note)
- `app/profile/ProfileDashboard.tsx`

`FinalizedEventView` and `TimeSlotPicker` were already correct and left unchanged.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `next lint` passes (changed files)
- [x] `vitest run` passes
- [ ] Manual: set OS timezone to a non-UTC zone (e.g. America/Chicago), open the manage page + voting page, confirm slot times match local time and show the `(CST)` label, and that values are stable across reloads/interactions
